### PR TITLE
feat: admin kill switch, header fix, creation disabled UX

### DIFF
--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { CosyLogo } from "@/components/layout/cosy-logo";
@@ -8,7 +9,11 @@ import TierBadge from "@/components/pixel/tier-badge.tsx";
 import useAuthInformation from "@/hooks/useAuthInformation/useAuthInformation.ts";
 import { useAppHeaderLogic } from "./useAppHeaderLogic";
 
-export function AppHeader() {
+interface AppHeaderProps {
+  rightSlot?: ReactNode;
+}
+
+export function AppHeader({ rightSlot }: AppHeaderProps = {}) {
   const { t } = useTranslation();
   const {
     userName,
@@ -22,27 +27,32 @@ export function AppHeader() {
 
   return (
     <header className="px-7 py-4 flex items-center gap-4 relative z-[5]">
-      <CosyLogo linkTo="/dashboard" testId="header-logo-link" />
+      <CosyLogo
+        linkTo={isUserLoggedIn ? "/dashboard" : "/"}
+        testId="header-logo-link"
+      />
       <div className="flex-1" />
 
-      <TierBadge tier={userTier ?? "FREE"} />
+      {!rightSlot && <TierBadge tier={userTier ?? "FREE"} />}
 
       <LanguageMenu />
-      {isUserLoggedIn ? (
-        <UserMenu
-          userName={userName}
-          isLoggingOut={isLoggingOut}
-          onLogout={handleLogout}
-          onDelete={handleDelete}
-        />
-      ) : (
-        <Link
-          to="/login"
-          data-testid="header-login-link"
-          className="pbtn sm secondary"
-        >
-          {t("nav.login")}
-        </Link>
+      {rightSlot ?? (
+        isUserLoggedIn ? (
+          <UserMenu
+            userName={userName}
+            isLoggingOut={isLoggingOut}
+            onLogout={handleLogout}
+            onDelete={handleDelete}
+          />
+        ) : (
+          <Link
+            to="/login"
+            data-testid="header-login-link"
+            className="pbtn sm secondary"
+          >
+            {t("nav.login")}
+          </Link>
+        )
       )}
     </header>
   );

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -11,9 +11,10 @@ import { useAppHeaderLogic } from "./useAppHeaderLogic";
 
 interface AppHeaderProps {
   rightSlot?: ReactNode;
+  logoLinkTo?: "/dashboard" | "/" | "/admin/subdomains";
 }
 
-export function AppHeader({ rightSlot }: AppHeaderProps = {}) {
+export function AppHeader({ rightSlot, logoLinkTo }: AppHeaderProps = {}) {
   const { t } = useTranslation();
   const {
     userName,
@@ -25,10 +26,13 @@ export function AppHeader({ rightSlot }: AppHeaderProps = {}) {
 
   const { userTier } = useAuthInformation();
 
+  const resolvedLogoLink =
+    logoLinkTo ?? (isUserLoggedIn ? "/dashboard" : "/");
+
   return (
     <header className="px-7 py-4 flex items-center gap-4 relative z-[5]">
       <CosyLogo
-        linkTo={isUserLoggedIn ? "/dashboard" : "/"}
+        linkTo={resolvedLogoLink}
         testId="header-logo-link"
       />
       <div className="flex-1" />

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -6,16 +6,18 @@ interface PageHeaderProps {
   children: ReactNode;
   maxWidth?: number;
   headerRightSlot?: ReactNode;
+  headerLogoLinkTo?: "/dashboard" | "/" | "/admin/subdomains";
 }
 
 export function PageHeader({
   children,
   maxWidth = 1200,
   headerRightSlot,
+  headerLogoLinkTo,
 }: PageHeaderProps) {
   return (
     <div className="sky-bg overflow-visible">
-      <AppHeader rightSlot={headerRightSlot} />
+      <AppHeader rightSlot={headerRightSlot} logoLinkTo={headerLogoLinkTo} />
       <div className="px-7 py-5 mx-auto" style={{ maxWidth }}>
         {children}
       </div>

--- a/src/components/layout/page-header.tsx
+++ b/src/components/layout/page-header.tsx
@@ -5,12 +5,17 @@ import { AppHeader } from "@/components/layout/app-header";
 interface PageHeaderProps {
   children: ReactNode;
   maxWidth?: number;
+  headerRightSlot?: ReactNode;
 }
 
-export function PageHeader({ children, maxWidth = 1200 }: PageHeaderProps) {
+export function PageHeader({
+  children,
+  maxWidth = 1200,
+  headerRightSlot,
+}: PageHeaderProps) {
   return (
     <div className="sky-bg overflow-visible">
-      <AppHeader />
+      <AppHeader rightSlot={headerRightSlot} />
       <div className="px-7 py-5 mx-auto" style={{ maxWidth }}>
         {children}
       </div>

--- a/src/hooks/useDataLoading/useDataLoading.ts
+++ b/src/hooks/useDataLoading/useDataLoading.ts
@@ -13,6 +13,7 @@ import {
   setIdentity,
 } from "@/store/auth-slice";
 import { useAppDispatch } from "@/store/hooks";
+import { setDomainCreationEnabled } from "@/store/settings-slice";
 import {
   setSubdomains,
   setSubdomainsError,
@@ -40,6 +41,15 @@ const useDataLoading = () => {
 
   const bootstrapAuth = useCallback(async () => {
     dispatch(setAuthState("loading"));
+
+    try {
+      const res = await fetch("/api/v1/settings");
+      const data = (await res.json()) as { domainCreationEnabled: boolean };
+      dispatch(setDomainCreationEnabled(data.domainCreationEnabled ?? true));
+    } catch {
+      // defaults to enabled if unreachable
+    }
+
     try {
       const token = await fetchToken();
       setIdentityToken(token);

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -144,6 +144,8 @@ const enCommon = {
       "You have used all your subdomain slots. Upgrade to Cosy+ to get access to 5 subdomains.",
     slotsExhaustedPlus:
       "You have used all your subdomain slots. If you need more subdomains, please contact the Cosy team.",
+    creationDisabled:
+      "Domain registration is currently disabled by the admin.",
   },
   createSubdomain: {
     title: "Register a new subdomain",
@@ -354,6 +356,7 @@ const enCommon = {
     label: "ADMIN",
     title: "Admin Dashboard",
     signOut: "Sign out",
+    exitPortal: "Exit Admin Portal",
     tabSubdomains: "Subdomains",
     tabUsers: "Users",
     adminKey: "Admin Key",
@@ -443,6 +446,14 @@ const enCommon = {
     deleteUserConfirm:
       "Are you sure you want to delete this user? All their subdomains and DNS records will also be deleted.",
     deleteUserError: "Failed to delete user.",
+    killSwitchTitle: "Domain Creation",
+    killSwitchDescription:
+      "When disabled, no new subdomains can be registered by any user.",
+    killSwitchEnabled: "Enabled",
+    killSwitchDisabled: "Disabled",
+    killSwitchEnable: "Enable",
+    killSwitchDisable: "Disable",
+    killSwitchToggling: "Updating...",
   },
   stagingAuth: {
     title: "Staging Environment",
@@ -617,6 +628,8 @@ const deCommon: CommonSchema = {
       "Du hast alle deine Subdomain-Slots belegt. Upgrade auf Cosy+, um Zugang zu 5 Subdomains zu erhalten.",
     slotsExhaustedPlus:
       "Du hast alle deine Subdomain-Slots belegt. Falls du mehr Subdomains benötigst, kontaktiere bitte das Cosy-Team.",
+    creationDisabled:
+      "Die Domain-Registrierung wurde vom Admin deaktiviert.",
   },
   createSubdomain: {
     title: "Neue Subdomain registrieren",
@@ -838,6 +851,7 @@ const deCommon: CommonSchema = {
     label: "ADMIN",
     title: "Admin-Dashboard",
     signOut: "Abmelden",
+    exitPortal: "Admin-Portal verlassen",
     tabSubdomains: "Subdomains",
     tabUsers: "Benutzer",
     adminKey: "Admin-Schlüssel",
@@ -927,6 +941,14 @@ const deCommon: CommonSchema = {
     deleteUserConfirm:
       "Bist du sicher, dass du diesen Benutzer löschen möchtest? Alle Subdomains und DNS-Einträge werden ebenfalls gelöscht.",
     deleteUserError: "Benutzer konnte nicht gelöscht werden.",
+    killSwitchTitle: "Domain-Erstellung",
+    killSwitchDescription:
+      "Wenn deaktiviert, können keine neuen Subdomains von Benutzern registriert werden.",
+    killSwitchEnabled: "Aktiv",
+    killSwitchDisabled: "Deaktiviert",
+    killSwitchEnable: "Aktivieren",
+    killSwitchDisable: "Deaktivieren",
+    killSwitchToggling: "Wird aktualisiert...",
   },
   stagingAuth: {
     title: "Staging-Umgebung",

--- a/src/pages/admin/components/subdomains-tab/components/kill-switch-panel.tsx
+++ b/src/pages/admin/components/subdomains-tab/components/kill-switch-panel.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from "react-i18next";
+
+import { FlatPanel } from "@/components/pixel/panel";
+
+import { useKillSwitchLogic } from "./useKillSwitchLogic";
+
+interface KillSwitchPanelProps {
+  adminKey: string;
+}
+
+export function KillSwitchPanel({ adminKey }: KillSwitchPanelProps) {
+  const { t } = useTranslation();
+  const { domainCreationEnabled, isLoading, isToggling, toggle } =
+    useKillSwitchLogic(adminKey);
+
+  if (isLoading) return null;
+
+  return (
+    <FlatPanel className="px-5 py-4 flex items-center gap-4">
+      <div className="flex-1">
+        <div className="pixel text-[10px] opacity-70">
+          {t("admin.killSwitchTitle")}
+        </div>
+        <div className="text-sm mt-1 opacity-75">
+          {t("admin.killSwitchDescription")}
+        </div>
+      </div>
+      <div className="flex items-center gap-3 shrink-0">
+        <span
+          className={`flex items-center gap-1.5 text-sm font-semibold ${domainCreationEnabled ? "text-green-600" : "text-destructive"}`}
+        >
+          <span
+            className={`inline-block w-2 h-2 rounded-full ${domainCreationEnabled ? "bg-green-600" : "bg-destructive"}`}
+          />
+          {domainCreationEnabled
+            ? t("admin.killSwitchEnabled")
+            : t("admin.killSwitchDisabled")}
+        </span>
+        <button
+          type="button"
+          onClick={toggle}
+          disabled={isToggling}
+          className={`pbtn sm ${domainCreationEnabled ? "destructive" : "primary"}`}
+        >
+          {isToggling
+            ? t("admin.killSwitchToggling")
+            : domainCreationEnabled
+              ? t("admin.killSwitchDisable")
+              : t("admin.killSwitchEnable")}
+        </button>
+      </div>
+    </FlatPanel>
+  );
+}

--- a/src/pages/admin/components/subdomains-tab/components/useKillSwitchLogic.ts
+++ b/src/pages/admin/components/subdomains-tab/components/useKillSwitchLogic.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { adminApi } from "../../../lib";
+
+export function useKillSwitchLogic(adminKey: string) {
+  const [domainCreationEnabled, setDomainCreationEnabled] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isToggling, setIsToggling] = useState(false);
+
+  useEffect(() => {
+    adminApi
+      .getSettings(adminKey)
+      .then((s) => setDomainCreationEnabled(s.domainCreationEnabled))
+      .finally(() => setIsLoading(false));
+  }, [adminKey]);
+
+  const toggle = useCallback(async () => {
+    setIsToggling(true);
+    try {
+      const updated = await adminApi.updateSettings(adminKey, {
+        domainCreationEnabled: !domainCreationEnabled,
+      });
+      setDomainCreationEnabled(updated.domainCreationEnabled);
+    } finally {
+      setIsToggling(false);
+    }
+  }, [adminKey, domainCreationEnabled]);
+
+  return { domainCreationEnabled, isLoading, isToggling, toggle };
+}

--- a/src/pages/admin/components/subdomains-tab/subdomains-tab.tsx
+++ b/src/pages/admin/components/subdomains-tab/subdomains-tab.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 
+import { KillSwitchPanel } from "./components/kill-switch-panel";
 import { SubdomainStats } from "./components/subdomain-stats";
 import { SubdomainsTable } from "./components/subdomains-table";
 import { useSubdomainsTabLogic } from "./useSubdomainsTabLogic";
@@ -19,6 +20,7 @@ export function SubdomainsTab({ adminKey }: SubdomainsTabProps) {
 
   return (
     <div className="flex flex-col gap-4">
+      <KillSwitchPanel adminKey={adminKey} />
       <SubdomainStats total={total} failed={failed} />
       <SubdomainsTable
         subdomains={subdomains}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -95,7 +95,7 @@ export function AdminAuthGate({ activeTab, outlet }: AdminAuthGateProps) {
 
   return (
     <div className="min-h-screen bg-background">
-      <PageHeader maxWidth={1200} headerRightSlot={exitButton}>
+      <PageHeader maxWidth={1200} headerRightSlot={exitButton} headerLogoLinkTo="/admin/subdomains">
         <div className="flex flex-col gap-2 mb-4">
           <div
             className="pixel text-[11px]"

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
+import { CosyLogo } from "@/components/layout/cosy-logo";
 import { PageHeader } from "@/components/layout/page-header";
 import { FlatPanel } from "@/components/pixel/panel";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,7 @@ export function AdminAuthGate({ activeTab, outlet }: AdminAuthGateProps) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center p-6">
         <div className="w-full max-w-sm flex flex-col gap-5">
+          <CosyLogo linkTo="/" />
           <div>
             <div
               className="pixel text-[11px] mb-1"
@@ -81,33 +83,34 @@ export function AdminAuthGate({ activeTab, outlet }: AdminAuthGateProps) {
     },
   ];
 
+  const exitButton = (
+    <button
+      type="button"
+      onClick={logout}
+      className="pbtn sm secondary shrink-0"
+    >
+      {t("admin.exitPortal")}
+    </button>
+  );
+
   return (
     <div className="min-h-screen bg-background">
-      <PageHeader maxWidth={1200}>
-        <div className="flex items-end gap-4 mb-4">
-          <div className="flex-1 flex flex-col gap-2">
-            <div
-              className="pixel text-[11px]"
-              style={{ color: "oklch(0.92 0.05 70)" }}
-            >
-              {t("admin.label")}
-            </div>
-            <h1
-              style={{
-                color: "oklch(0.95 0.08 70)",
-                textShadow: "3px 3px 0 oklch(0.25 0.08 30)",
-              }}
-            >
-              {t("admin.title")}
-            </h1>
-          </div>
-          <button
-            type="button"
-            onClick={logout}
-            className="pbtn sm secondary shrink-0"
+      <PageHeader maxWidth={1200} headerRightSlot={exitButton}>
+        <div className="flex flex-col gap-2 mb-4">
+          <div
+            className="pixel text-[11px]"
+            style={{ color: "oklch(0.92 0.05 70)" }}
           >
-            {t("admin.signOut")}
-          </button>
+            {t("admin.label")}
+          </div>
+          <h1
+            style={{
+              color: "oklch(0.95 0.08 70)",
+              textShadow: "3px 3px 0 oklch(0.25 0.08 30)",
+            }}
+          >
+            {t("admin.title")}
+          </h1>
         </div>
 
         <div

--- a/src/pages/admin/lib.ts
+++ b/src/pages/admin/lib.ts
@@ -106,6 +106,18 @@ export const adminApi = {
       method: "PATCH",
       body: JSON.stringify({ maxSubdomainCountOverride: value }),
     }),
+
+  getSettings: (key: string) => request<AdminSettings>(`${BASE}/settings`, key),
+
+  updateSettings: (key: string, body: Partial<AdminSettings>) =>
+    request<AdminSettings>(`${BASE}/settings`, key, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
 };
+
+export interface AdminSettings {
+  domainCreationEnabled: boolean;
+}
 
 export const ADMIN_KEY_STORAGE = "admin_key";

--- a/src/pages/dashboard/components/dashboard-banner.tsx
+++ b/src/pages/dashboard/components/dashboard-banner.tsx
@@ -7,6 +7,7 @@ interface DashboardBannerProps {
   isVerified: boolean;
   isMfaEnabled: boolean;
   isSlotsExhausted: boolean;
+  domainCreationEnabled: boolean;
   userTier: "FREE" | "PLUS" | null;
   onCreateNew: () => void;
 }
@@ -15,16 +16,21 @@ export function DashboardBanner({
   isVerified,
   isMfaEnabled,
   isSlotsExhausted,
+  domainCreationEnabled,
   userTier,
   onCreateNew,
 }: DashboardBannerProps) {
   const { t } = useTranslation();
 
-  const tooltipText = isSlotsExhausted
-    ? userTier === "PLUS"
-      ? t("dashboard.slotsExhaustedPlus")
-      : t("dashboard.slotsExhaustedFree")
-    : null;
+  const isButtonDisabled = !domainCreationEnabled || isSlotsExhausted;
+
+  const tooltipText = !domainCreationEnabled
+    ? t("dashboard.creationDisabled")
+    : isSlotsExhausted
+      ? userTier === "PLUS"
+        ? t("dashboard.slotsExhaustedPlus")
+        : t("dashboard.slotsExhaustedFree")
+      : null;
 
   return (
     <PageHeader>
@@ -52,7 +58,7 @@ export function DashboardBanner({
             data-testid="dashboard-create-new-btn"
             size="lg"
             onClick={onCreateNew}
-            disabled={isSlotsExhausted}
+            disabled={isButtonDisabled}
           >
             {!isVerified ? (
               t("dashboard.verifyAccount")

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -13,6 +13,7 @@ export function DashboardPage() {
     isMfaEnabled,
     userTier,
     isSlotsExhausted,
+    domainCreationEnabled,
     handleCreateNew,
   } = useDashboardLogic();
 
@@ -22,6 +23,7 @@ export function DashboardPage() {
         isVerified={isVerified}
         isMfaEnabled={isMfaEnabled}
         isSlotsExhausted={isSlotsExhausted}
+        domainCreationEnabled={domainCreationEnabled}
         userTier={userTier}
         onCreateNew={handleCreateNew}
       />

--- a/src/pages/dashboard/useDashboardLogic.ts
+++ b/src/pages/dashboard/useDashboardLogic.ts
@@ -19,6 +19,9 @@ export function useDashboardLogic() {
 
   const isSlotsExhausted =
     maxSubdomainCount !== null && subdomains.length >= maxSubdomainCount;
+  const domainCreationEnabled = useAppSelector(
+    (state) => state.settings.domainCreationEnabled,
+  );
 
   const handleCreateNew = useCallback(() => {
     if (!isVerified) {
@@ -38,6 +41,7 @@ export function useDashboardLogic() {
     isMfaEnabled,
     userTier,
     isSlotsExhausted,
+    domainCreationEnabled,
     handleCreateNew,
   };
 }

--- a/src/store/settings-slice.ts
+++ b/src/store/settings-slice.ts
@@ -1,0 +1,22 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+interface SettingsState {
+  domainCreationEnabled: boolean;
+}
+
+const initialState: SettingsState = {
+  domainCreationEnabled: true,
+};
+
+const settingsSlice = createSlice({
+  name: "settings",
+  initialState,
+  reducers: {
+    setDomainCreationEnabled(state, action: PayloadAction<boolean>) {
+      state.domainCreationEnabled = action.payload;
+    },
+  },
+});
+
+export const { setDomainCreationEnabled } = settingsSlice.actions;
+export const settingsReducer = settingsSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,12 +1,14 @@
 import { configureStore } from "@reduxjs/toolkit";
 
 import { authReducer } from "@/store/auth-slice";
+import { settingsReducer } from "@/store/settings-slice";
 import { subdomainsReducer } from "@/store/subdomains-slice";
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     subdomains: subdomainsReducer,
+    settings: settingsReducer,
   },
 });
 


### PR DESCRIPTION
## Summary
- Kill switch toggle in admin subdomains tab (enable/disable domain creation globally)
- Public `GET /api/v1/settings` fetched on bootstrap → disables Create New button with tooltip when kill switch is off
- Admin portal header: CosyLogo added, "Exit Admin Portal" button in top bar replaces login button
- AppHeader logo now routes to `/` when logged out, `/dashboard` when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)