### PR TITLE
fix(watchtower): let a click outside the detail dialog close it

### DIFF
--- a/src/pages/admin/components/watchtower-tab/components/watchtower-detail/watchtower-detail.test.tsx
+++ b/src/pages/admin/components/watchtower-tab/components/watchtower-detail/watchtower-detail.test.tsx
@@ -159,6 +159,38 @@ describe("WatchtowerDetail", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("closes when the backdrop is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <WatchtowerDetail
+        scan={scan({})}
+        onClose={onClose}
+        onSubmitReview={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByTestId("watchtower-detail-backdrop"));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("stays open when the panel itself is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <WatchtowerDetail
+        scan={scan({})}
+        onClose={onClose}
+        onSubmitReview={vi.fn()}
+      />,
+    );
+
+    // A click that bubbles up from inside the panel must not dismiss the dialog —
+    // otherwise selecting text in the summary would throw away a drafted note.
+    await userEvent.click(screen.getByText("Crypto scam pattern"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("closes on Escape", async () => {
     const onClose = vi.fn();
     render(

--- a/src/pages/admin/components/watchtower-tab/components/watchtower-detail/watchtower-detail.tsx
+++ b/src/pages/admin/components/watchtower-tab/components/watchtower-detail/watchtower-detail.tsx
@@ -39,7 +39,19 @@ export function WatchtowerDetail({
       className="fixed inset-0 z-50 w-full h-full max-w-none max-h-none bg-black/50 flex items-center justify-center p-4"
       data-testid="watchtower-detail"
     >
-      <FlatPanel className="w-full max-w-[880px] max-h-full overflow-y-auto p-6 flex flex-col gap-4">
+      {/*
+        A real button rather than a click handler on the dialog: the backdrop is
+        then reachable by keyboard too, and clicks inside the panel never reach it,
+        so selecting summary text cannot throw away a half-written review note.
+      */}
+      <button
+        type="button"
+        aria-label={t("watchtower.close")}
+        onClick={onClose}
+        data-testid="watchtower-detail-backdrop"
+        className="absolute inset-0 w-full h-full cursor-default"
+      />
+      <FlatPanel className="relative z-10 w-full max-w-[880px] max-h-full overflow-y-auto p-6 flex flex-col gap-4">
         <div className="flex items-start justify-between gap-4">
           <div className="flex flex-col gap-1">
             <h3>{scan.label}</h3>


### PR DESCRIPTION
Clicking the dimmed area around the scan detail dialog now closes it. Escape already worked, but nothing hinted at it.

Built as a real backdrop `<button>` rather than an `onClick` on the `<dialog>`:

- keyboard-reachable, so it needs no a11y suppression
- clicks bubbling out of the panel cannot reach it, so selecting text in the summary can't discard a drafted review note

🤖 Generated with [Claude Code](https://claude.com/claude-code)