### PR TITLE
fix(watchtower): readable EMPTY badge, less raw white

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,7 @@
     --accent-3: oklch(0.65 0.1 240);
     --accent-4: oklch(0.6 0.22 340);
     --white: oklch(94.99% 0.01095 63.101);
+    --muted: oklch(58% 0.035 40);
     --shadow: oklch(29.893% 0.11327 316.782 / 55%);
     --destructive: oklch(0.55 0.22 25);
     --success: oklch(0.58 0.17 150);

--- a/src/pages/admin/components/watchtower-tab/components/watchtower-card/watchtower-card.tsx
+++ b/src/pages/admin/components/watchtower-tab/components/watchtower-card/watchtower-card.tsx
@@ -19,11 +19,11 @@ export function WatchtowerCard({ scan, onSelect }: WatchtowerCardProps) {
       type="button"
       onClick={() => onSelect(scan.uuid)}
       data-testid={`watchtower-card-${scan.label}`}
-      className={`bg-white border-[3px] ${accent.border} rounded-radius-lg overflow-hidden flex flex-col text-left cursor-pointer`}
+      className={`bg-secondary-background border-[3px] ${accent.border} rounded-radius-lg overflow-hidden flex flex-col text-left cursor-pointer`}
       style={{ boxShadow: "6px 6px 0 0 var(--shadow)" }}
     >
       <div
-        className={`h-[180px] overflow-hidden border-b-[3px] ${accent.border} bg-secondary-background relative`}
+        className={`h-[180px] overflow-hidden border-b-[3px] ${accent.border} bg-background relative`}
       >
         {scan.screenshotUrl ? (
           <img
@@ -38,7 +38,7 @@ export function WatchtowerCard({ scan, onSelect }: WatchtowerCardProps) {
           </div>
         )}
         {needsReview(scan) ? (
-          <span className="pixel text-[9px] absolute top-2 right-2 bg-destructive text-white border-2 border-foreground rounded-radius-sm px-2 py-1">
+          <span className="pixel text-[9px] absolute top-2 right-2 bg-destructive text-paper border-2 border-foreground rounded-radius-sm px-2 py-1">
             {t("watchtower.needsReview")}
           </span>
         ) : null}

--- a/src/pages/admin/components/watchtower-tab/components/watchtower-summary/watchtower-summary.tsx
+++ b/src/pages/admin/components/watchtower-tab/components/watchtower-summary/watchtower-summary.tsx
@@ -28,7 +28,7 @@ export function WatchtowerSummary({ summary }: WatchtowerSummaryProps) {
       label: t("watchtower.statBenign"),
       value: summary.benign,
       sub: t("watchtower.statBenignSub"),
-      color: "text-green-600",
+      color: "text-success",
     },
     {
       label: t("watchtower.statFlagged"),

--- a/src/pages/admin/components/watchtower-tab/components/watchtower-toolbar/watchtower-toolbar.tsx
+++ b/src/pages/admin/components/watchtower-tab/components/watchtower-toolbar/watchtower-toolbar.tsx
@@ -45,8 +45,8 @@ export function WatchtowerToolbar({
             data-testid={`watchtower-view-${v}`}
             className={`pixel text-[10px] px-4 py-3 cursor-pointer ${
               view === v
-                ? "bg-foreground text-white"
-                : "bg-white text-foreground"
+                ? "bg-foreground text-paper"
+                : "bg-secondary-background text-foreground"
             }`}
           >
             {t(`watchtower.view.${v}`)}
@@ -63,10 +63,10 @@ export function WatchtowerToolbar({
             data-testid={`watchtower-filter-${key}`}
             className={`text-[17px] border-2 rounded-radius-sm px-3 py-1 cursor-pointer ${
               filter === key
-                ? "bg-foreground text-white border-foreground"
+                ? "bg-foreground text-paper border-foreground"
                 : key === "flagged"
-                  ? "bg-white text-destructive border-destructive"
-                  : "bg-white text-foreground border-foreground"
+                  ? "bg-secondary-background text-destructive border-destructive"
+                  : "bg-secondary-background text-foreground border-foreground"
             }`}
           >
             {t(`watchtower.filter.${key}`)}

--- a/src/pages/admin/components/watchtower-tab/lib.test.ts
+++ b/src/pages/admin/components/watchtower-tab/lib.test.ts
@@ -154,6 +154,38 @@ describe("categoryAccent", () => {
     );
   });
 
+  it("never uses an opacity modifier on a token colour", () => {
+    // Every palette colour is a bare `var(--token)`, so `bg-foreground/50` compiles
+    // to nothing and the badge renders with no background — which once made the
+    // EMPTY badge white text on a white card.
+    for (const category of [
+      "COSY_FRONTEND",
+      "BENIGN",
+      "EMPTY",
+      "SUSPICIOUS",
+      "MALICIOUS",
+      "UNREACHABLE",
+    ] as const) {
+      const accent = categoryAccent(category);
+      expect(`${accent.border} ${accent.badge} ${accent.text}`).not.toContain(
+        "/",
+      );
+    }
+  });
+
+  it("pairs every badge fill with an explicit text colour", () => {
+    for (const category of [
+      "COSY_FRONTEND",
+      "BENIGN",
+      "EMPTY",
+      "SUSPICIOUS",
+      "MALICIOUS",
+      "UNREACHABLE",
+    ] as const) {
+      expect(categoryAccent(category).badge).toMatch(/\btext-\S+/);
+    }
+  });
+
   it("gives UNREACHABLE a neutral accent", () => {
     expect(categoryAccent("UNREACHABLE").border).toBe("border-foreground");
   });

--- a/src/pages/admin/components/watchtower-tab/lib.ts
+++ b/src/pages/admin/components/watchtower-tab/lib.ts
@@ -39,37 +39,37 @@ export function categoryAccent(category: WatchtowerCategory): {
     case "COSY_FRONTEND":
       return {
         border: "border-foreground",
-        badge: "bg-accent-3 text-white",
+        badge: "bg-accent-3 text-paper",
         text: "text-foreground",
       };
     case "BENIGN":
       return {
         border: "border-foreground",
-        badge: "bg-success text-white",
+        badge: "bg-success text-paper",
         text: "text-foreground",
       };
     case "EMPTY":
       return {
         border: "border-foreground",
-        badge: "bg-foreground/50 text-white",
+        badge: "bg-muted text-paper",
         text: "text-foreground",
       };
     case "SUSPICIOUS":
       return {
         border: "border-accent",
-        badge: "bg-accent text-white",
+        badge: "bg-accent text-foreground",
         text: "text-foreground",
       };
     case "MALICIOUS":
       return {
         border: "border-destructive",
-        badge: "bg-destructive text-white",
+        badge: "bg-destructive text-paper",
         text: "text-destructive",
       };
     case "UNREACHABLE":
       return {
         border: "border-foreground",
-        badge: "bg-foreground text-white",
+        badge: "bg-foreground text-paper",
         text: "text-foreground",
       };
   }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,10 +11,16 @@ const config: Config = {
       },
     },
     extend: {
+      // NOTE: every colour below resolves to a bare `var(--token)`, so Tailwind's
+      // opacity modifiers (`bg-foreground/50`) produce invalid CSS and are dropped
+      // silently — the element then renders with no background at all. Pick a token
+      // that already has the shade you want instead.
       colors: {
         background: "var(--background)",
         "secondary-background": "var(--secondary-background)",
         foreground: "var(--foreground)",
+        muted: "var(--muted)",
+        paper: "var(--white)",
         accent: "var(--accent)",
         "accent-2": "var(--accent-2)",
         "accent-3": "var(--accent-3)",


### PR DESCRIPTION
The watchtower dashboard's `EMPTY` badge rendered as white text on a white card.

**Cause:** `categoryAccent("EMPTY").badge` was `bg-foreground/50`. Every palette colour in `tailwind.config.ts` is a bare `var(--token)`, so Tailwind's opacity modifier compiles to invalid CSS and the utility is dropped silently — the badge had *no* background at all, on a `bg-white` card.

**Fix:**
- new `--muted` token (`bg-muted text-paper` for EMPTY), plus a `paper` token for the palette's warm off-white so no badge uses raw `#fff` text
- dashboard surfaces (cards, view toggle, filter chips) move from `bg-white` to the `bg-secondary-background` panel tone the rest of the app uses; card screenshot frames sit on `bg-background`
- summary `text-green-600` → the `text-success` token
- regression tests: no accent may use an opacity modifier, every badge fill must carry an explicit text colour
- a comment in `tailwind.config.ts` documenting the var-token/opacity trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)